### PR TITLE
Fix requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-python>=3.8
 XlsxWriter
 pandas
 numpy


### PR DESCRIPTION
Requirements shouldn't contain python version. -> leads to errors using pip install -r requirements.txt